### PR TITLE
fix: set postgres user to fix global.stat warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     restart: always
     image: postgres:13
     container_name: asv-db
+    user: postgres
     volumes:
       # These files are read during database startup, and can be used to define
       # the database schema and roles. The files are read in file name order, so


### PR DESCRIPTION
The permission denied warnings for `global.stat` was caused by using the default docker user (`root`) instead of the postgres intended user (`postgres`), so this PR fixes the errors by explicitly setting the correct user.