### PR TITLE
Add basic log config to docker-compose file

### DIFF
--- a/blast-worker/worker.py
+++ b/blast-worker/worker.py
@@ -6,10 +6,25 @@ the future.
 """
 
 import os
+import json
 import subprocess
+from logging.config import dictConfig
+
 from flask import Flask, jsonify, request
 
+#
 # Start server
+#
+
+# Figure out environment to set log config
+environment = os.getenv('FLASK_ENV')
+if environment != 'production':
+    environment = 'development'
+
+# Load log config, and create log before flask app
+log_config = json.load(open(f'log/log_config_{environment}.json'))
+dictConfig(log_config)
+
 APP = Flask(__name__)
 APP.jobs = 0
 
@@ -89,7 +104,7 @@ def main():
         # If BLAST returns success response
         if process.returncode == 0:
             # pylint: disable=no-member
-            APP.logger.info('BLAST success')
+            APP.logger.debug('BLAST success')
 
             #
             # Format results as JSON, to make it easier to parse.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
     build:
       context: ./
       dockerfile: docker/blast
+    logging: *default-logging
     volumes:
       - ./blast-databases:/blastdbs
   develop:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,28 @@
 version: "3.8"
+# logging:
+# the docker-compose logging documentation is at:
+# https://docs.docker.com/compose/compose-file/compose-file-v3/#logging
+# logging options are documented at:
+# https://docs.docker.com/config/containers/logging/configure/
+#
+# Logging is generally configured on the service level, that is - you define
+# a logging entry for every service. This can be useful, but for now we use the
+# extension field syntax to define a logger that we reuse for all services.
+#
+x-logging:
+  &default-logging
+  driver: "json-file" # this is the default logger
+  options:
+    max-size: '20m'
+    max-file: '5'
+    compress: 'true'
+
 services:
   postgres:
     restart: always
     image: postgres:13
     container_name: asv-db
-    user: postgres
+    logging: *default-logging
     volumes:
       # Files read (in alphanumeric order) during database startup,
       # and used to define database schema and roles
@@ -25,6 +43,10 @@ services:
     restart: always
     image: postgrest/postgrest:v7.0.1
     container_name: asv-rest
+    logging: *default-logging
+    # for debugging, this syntax can be used to connect a host port to a
+    # container port (HOST:CONTAINER), but the containers can connect to each
+    # other regardless.
     # ports:
     #   - 3000:3000
     # Get most environment variables from the default .env file
@@ -46,6 +68,7 @@ services:
     build:
       context: ./
       dockerfile: docker/develop
+    logging: *default-logging
     volumes:
       - type: bind
         source: ./

--- a/docker/blast
+++ b/docker/blast
@@ -2,6 +2,7 @@
 FROM ncbi/blast:2.10.1
 
 ADD blast-worker/ /worker
+ADD log/ /worker/log
 
 WORKDIR /worker
 


### PR DESCRIPTION
I had planned to complete this branch when I had a logging target, but for now - let's just use the default logging, but do it explicitly.