### PR TITLE
Feature/limit result rows

### DIFF
--- a/molmod/forms.py
+++ b/molmod/forms.py
@@ -23,9 +23,9 @@ TGGGGAATTTTGCGCAATGGGGGAAACCCTGACGCAGCAACGCCGCGTGGAGGATGAAGCCCCTTGGGGTGTAAACTCCT
 def fasta_check(form, field):
     if len(field.data) < 1:
         raise ValidationError('Please submit an input sequence')
-    if len(field.data) > 500000:
+    if len(field.data) > 50000:
         raise ValidationError('''Input sequence must be less
-                              than 500000 characters''')
+                              than 50000 characters''')
 
     # Check that this is actually a valid fasta file, that we can process
     fasta_chars = r'AaCcGgTtUuIiRrYyKkMmSsWwBbDdHhVvNn\-'

--- a/molmod/routes/blast_routes.py
+++ b/molmod/routes/blast_routes.py
@@ -61,6 +61,9 @@ def blast_run():
     results = response.json()
     results = results['data'] if 'data' in results else results
 
+    # Limit results sent to browser to max 1000 rows
+    results = results[0:1000]
+
     # Format result fields
     for result in results:
         # Set single decimal for Sci not & float

--- a/molmod/routes/filter_routes.py
+++ b/molmod/routes/filter_routes.py
@@ -102,7 +102,7 @@ def filter_run() -> dict:
         url += '?'
         for filter, value in selections.items():
             url += f'&{filter}=in.({value})'
-    APP.logger.debug(f'URL for API request: {url}')
+    # APP.logger.debug(f'URL for API request: {url}')
 
     #
     # Send API request
@@ -115,5 +115,5 @@ def filter_run() -> dict:
         APP.logger.error(f'API request for filtered occurences returned: {e}')
     else:
         results = json.loads(response.text)[0:1000]
-        APP.logger.debug(results)
+        # APP.logger.debug(results)
         return {"data": results}

--- a/molmod/routes/filter_routes.py
+++ b/molmod/routes/filter_routes.py
@@ -114,4 +114,6 @@ def filter_run() -> dict:
     except (requests.ConnectionError, requests.exceptions.HTTPError) as e:
         APP.logger.error(f'API request for filtered occurences returned: {e}')
     else:
-        return {"data": json.loads(response.text)}
+        results = json.loads(response.text)[0:1000]
+        APP.logger.debug(results)
+        return {"data": results}

--- a/molmod/static/js/main.js
+++ b/molmod/static/js/main.js
@@ -8,8 +8,12 @@ $(document).ready(function() {
 
         // BLAST PAGE
         case 'blast':
+            // Update info on query sequence length
+            // after BLAST (page is reloaded)
+            updateSeqLength();
+            // and when textarea input changes
             $('#sequence_textarea').on('input', function(){
-                $('#sequence_count').text($(this).val().length+'/50000 characters');
+                updateSeqLength();
             });
             // Define columns for BLAST search result table
             var columns = [
@@ -249,4 +253,11 @@ function makeDataTbl(url, columns) {
         buttons: [ 'excel', 'csv' ]
     });
     return dTbl;
+}
+
+function updateSeqLength() {
+    // Counts no. of characters (incl. invisibles) in query sequence(s)
+    // and shows this number above textarea
+    var seqLength = $('#sequence_textarea').val().length;
+    $('#sequence_count').text(seqLength + '/50000 characters');
 }

--- a/molmod/static/js/main.js
+++ b/molmod/static/js/main.js
@@ -229,6 +229,10 @@ function makeDataTbl(url, columns) {
                     $("#show_occurrences").prop("disabled",true);
                     dTbl.buttons().disable();
                 }
+                if (json.data.length > 999) {
+                    $('#search_err_container').html('Only the first 1000 rows are shown. '
+                      + 'Please, refine your search to make sure results are not truncated.');
+                }
                 return json.data;
             } ,
             // Include CSRF-token in POST

--- a/molmod/static/js/main.js
+++ b/molmod/static/js/main.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
         // BLAST PAGE
         case 'blast':
             $('#sequence_textarea').on('input', function(){
-                $('#sequence_count').text($(this).val().length+'/500000 characters');
+                $('#sequence_count').text($(this).val().length+'/50000 characters');
             });
             // Define columns for BLAST search result table
             var columns = [

--- a/molmod/templates/blast.html
+++ b/molmod/templates/blast.html
@@ -23,9 +23,9 @@
                         <p>
                             <b>Query sequence(s)</b>
                             <br>Nucleotide sequence(s), in fasta format, to compare against ASVs (subject sequences) in reference database
-                            <span style='float: right' id='sequence_count'>2108/500000 characters</span>
+                            <span style='float: right' id='sequence_count'>2108/50000 characters</span>
                         </p>
-                            {{ sform.sequence(id='sequence_textarea', rows=8, cols=80, maxlength='500000', class='form-control') }}
+                            {{ sform.sequence(id='sequence_textarea', rows=8, cols=80, maxlength='50000', class='form-control') }}
                             <span id='helpBlock2' class='help-block'>
                                 {% for error in sform.sequence.errors %}
                                 {{ error }}


### PR DESCRIPTION
Simple feature that limits the number of records shown in both BLAST and filter search result tables, and warns when results have been truncated. Truncation is done before results are sent to browser, in response to Ajax request. No limits are applied to db (as I could not see that it helped speed anything up, but should perhaps be looked into later). Also updates sequence character count after BLAST submit. Assumes BLAST results are sorted according to E-value, before being sent to browser, which seems to be the case.