### PR TITLE
Avoid creation of some anonymous volumes

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,7 @@ x-logging:
 volumes:
   postgres-db:
   blast-db:
+  blastconfig:
 
 secrets:
   postgres_pass:
@@ -80,6 +81,7 @@ services:
       - FLASK_ENV=production
     volumes:
       - blast-db:/blastdbs
+      - blastconfig:/root/.config
 
   asv-main:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - postgres_pass
     volumes:
       - ./blast-databases:/blastdbs
+      - blastconfig:/root/.config
 
   develop:
     container_name: asv-main
@@ -108,3 +109,6 @@ services:
       - 5000:5000
     depends_on:
       - postgrest
+
+volumes:
+  blastconfig:


### PR DESCRIPTION
Supply a volume to be mounted to `/root/.config` to avoid anonymous volume creation.