### PR TITLE
Set MAX_CONTENT_LENGTH from environment

### DIFF
--- a/.env
+++ b/.env
@@ -27,7 +27,7 @@ CAS_SERVER=https://auth.biodiversitydata.se
 CAS_AFTER_LOGIN=main_bp.index
 
 # File upload
-# MAX_CONTENT_LENGTH=1024
+MAX_CONTENT_LENGTH=838860800
 UPLOAD_PATH=/uploads
 UPLOAD_ROLE=ROLE_MOLMOD_USER
 

--- a/.env
+++ b/.env
@@ -27,8 +27,8 @@ CAS_SERVER=https://auth.biodiversitydata.se
 CAS_AFTER_LOGIN=main_bp.index
 
 # File upload
-# Size limit is set in nginx (molecular.conf: client_max_body_size 800m;),
-# but also here, to show flask (rather than nginx) error page
+# Note that size limit set in nginx (molecular.conf: client_max_body_size 800m)
+# needs to correspond to this setting:
 MAX_CONTENT_LENGTH=838860800 # 800 * 1024 * 1024 Bytes
 UPLOAD_PATH=/uploads
 UPLOAD_ROLE=ROLE_MOLMOD_USER

--- a/.env
+++ b/.env
@@ -27,7 +27,9 @@ CAS_SERVER=https://auth.biodiversitydata.se
 CAS_AFTER_LOGIN=main_bp.index
 
 # File upload
-MAX_CONTENT_LENGTH=838860800
+# Size limit is set in nginx (molecular.conf: client_max_body_size 800m;),
+# but also here, to show flask (rather than nginx) error page
+MAX_CONTENT_LENGTH=838860800 # 800 * 1024 * 1024 Bytes
 UPLOAD_PATH=/uploads
 UPLOAD_ROLE=ROLE_MOLMOD_USER
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Note that you may have to edit firewall settings to allow incoming connections t
 ```
 
 ### File uploads
-We set the size limit of uploaded files both in nginx proxy (client_max_body_size), but also in the flask .env file (MAX_CONTENT_LENGTH) to be able to show a flask (rather than nginx) error page. Note that neither the flask development server nor uwsgi handles this well, resulting in a connection reset error instead of a 413 response (See Connection Reset Issue in [Flask documentation](https://flask.palletsprojects.com/en/1.1.x/patterns/fileuploads/) when testing locally.
+The size limit you set in nginx (molecular.conf: client_max_body_size) needs to correspond to the setting in flask (.env: MAX_CONTENT_LENGTH) for restriction to work properly. Note that neither the flask development server nor uwsgi handles this well, resulting in a connection reset error instead of a 413 response (See Connection Reset Issue in [Flask documentation](https://flask.palletsprojects.com/en/1.1.x/patterns/fileuploads/) when testing locally.
 
 You can list uploaded files in running asv-main container:
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Note that you may have to edit firewall settings to allow incoming connections t
 ```
 
 ### File uploads
+We set the size limit of uploaded files both in nginx proxy (client_max_body_size), but also in the flask .env file (MAX_CONTENT_LENGTH) to be able to show a flask (rather than nginx) error page. Note that neither the flask development server nor uwsgi handles this well, resulting in a connection reset error instead of a 413 response (See Connection Reset Issue in [Flask documentation](https://flask.palletsprojects.com/en/1.1.x/patterns/fileuploads/) when testing locally.
+
 You can list uploaded files in running asv-main container:
 ```
   $ docker exec asv-main ls /uploads

--- a/molmod/__init__.py
+++ b/molmod/__init__.py
@@ -66,7 +66,8 @@ def create_app():
             bioatlas_page=CONFIG.BIOATLAS_PAGE,
             taxonomy_page=CONFIG.TAXONOMY_PAGE,
             user=user,
-            firstname=firstname
+            firstname=firstname,
+            max_file_size=CONFIG.MAX_CONTENT_LENGTH
         )
 
     with app.app_context():

--- a/molmod/config.py
+++ b/molmod/config.py
@@ -32,6 +32,7 @@ class Config:
     CAS_SERVER = get_env_variable('CAS_SERVER')
     CAS_AFTER_LOGIN = get_env_variable('CAS_AFTER_LOGIN')
     UPLOAD_PATH = get_env_variable('UPLOAD_PATH')
+    MAX_CONTENT_LENGTH = int(get_env_variable('MAX_CONTENT_LENGTH'))
     # Cache settings (Flask internal), but see also molecular.config in proxy
     # (https://github.com/biodiversitydata-se/proxy-ws-mol-mod-docker)
     SEND_FILE_MAX_AGE_DEFAULT = 300  # 300 seconds = 5 minutes

--- a/molmod/forms.py
+++ b/molmod/forms.py
@@ -90,7 +90,7 @@ def file_check(form, field):
     file = field.data
 
     if not file or not file.filename:
-        raise ValidationError('No file supplied')
+        raise ValidationError('Please select a file.')
 
     parts = file.filename.lower().split('.')
     APP.logger.debug(f'{file.filename} is split into {parts}')

--- a/molmod/routes/main_routes.py
+++ b/molmod/routes/main_routes.py
@@ -84,7 +84,7 @@ def upload():
     # User has tried to submit file (POST)
     # Check if it passes (simple) validation in forms.py
     if not form.validate_on_submit():
-        return render_template('upload.html', form=form, upload_error=True)
+        return render_template('upload.html', form=form)
 
     # Get filename
     f = form.file.data

--- a/molmod/static/css/main.css
+++ b/molmod/static/css/main.css
@@ -91,5 +91,5 @@ tr.shown td.details-control {
 #file-shown {
   padding: 10px;
   display: inline-block;
-  width: 300px;
+  width: 400px;
 }

--- a/molmod/templates/error_413.html
+++ b/molmod/templates/error_413.html
@@ -1,0 +1,19 @@
+{% extends "layout.html" %}
+{% block title %}Page Not Found{% endblock %}
+{% block body %}
+<div class='container'>
+    <div>
+        <br>
+        <h3>File Too Large</h3>
+        <br>
+        <p>The file you tried to upload was larger than the {{ "{:.0f}".format(max_file_size/(1024*1024)) }}
+           MB we can deal with here.
+       </p>
+       <p>
+           Please contact <a href="{{ sbdi_contact_page }}">SBDI support</a>,
+           and we will find another option for you.
+        </p>
+
+    </div>
+</div>
+{% endblock body %}

--- a/molmod/templates/layout.html
+++ b/molmod/templates/layout.html
@@ -32,15 +32,6 @@
         {% block body %}
         {% endblock body %}
     </div>
-    <div class="container" style="color: #aa4442">
-        {% with messages = get_flashed_messages() %}
-            {% if messages %}
-                {% for message in messages %}
-                    {{ message }} <br>
-                {% endfor %}
-            {% endif %}
-        {% endwith %}
-    </div>
     {% include ['footer.html'] ignore missing %}
     <!-- Bootstrap, jQuery, DataTables w. Select & button ext -->
     <script src="https://cdn.datatables.net/v/bs-3.3.7/jq-3.3.1/jszip-2.5.0/dt-1.10.22/b-1.6.5/b-html5-1.6.5/sl-1.3.1/datatables.min.js"></script>

--- a/molmod/templates/upload.html
+++ b/molmod/templates/upload.html
@@ -5,8 +5,8 @@
         <br>
         <h3>Upload data to the ASV database</h3>
         <br>
-        <p>Select an Excel or compressed archive file (<i>*.tar.gz, *.tar.bz2 och *.tar.lz</i>) to submit.
-            <br>Archives should contain a folder of comma-separated (<i>*.csv</i>) text files, each named after the original template sheet, e.g. <i>asv-table.csv</i>.
+        <p>Select an Excel (xlsx) or compressed archive file (tar.gz, tar.bz2 och tar.lz) to submit.
+           Archives should contain a folder of comma-separated (csv) text files, each named after the original template sheet.
        </p>
     </div>
     <form method='post' id='form' enctype='multipart/form-data'>


### PR DESCRIPTION
Tell flask to allow larger bodies by setting`MAX_CONTENT_LENGTH` from the environment.