### PR TITLE
Set MAX_CONTENT_LENGTH to a single numeric value

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,8 @@ CAS_AFTER_LOGIN=main_bp.index
 # File upload
 # Note that size limit set in nginx (molecular.conf: client_max_body_size 800m)
 # needs to correspond to this setting:
-MAX_CONTENT_LENGTH=838860800 # 800 * 1024 * 1024 Bytes
+# 838860800 = 800 * 1024 * 1024 Bytes
+MAX_CONTENT_LENGTH=838860800
 UPLOAD_PATH=/uploads
 UPLOAD_ROLE=ROLE_MOLMOD_USER
 VALID_EXTENSIONS=xlsx xlsx.zip tar.gz tar.bz2 tar.lz


### PR DESCRIPTION
`.env` files aren't exactly executed by bash, so comments on the same line does not behave as one might expect.