### PR TITLE
Feature/delete dataset

### DIFF
--- a/db/db-data-schema.sql
+++ b/db/db-data-schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS public.dataset (
 CREATE TABLE IF NOT EXISTS public.sampling_event (
     pid BIGSERIAL PRIMARY KEY,
     material_sample_id character varying,
-    dataset_pid integer REFERENCES public.dataset(pid) NOT NULL,
+    dataset_pid integer NOT NULL REFERENCES public.dataset(pid) ON DELETE CASCADE,
     event_date character varying NOT NULL,
     sampling_protocol character varying NOT NULL,
     sample_size_value integer NOT NULL,
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS public.sampling_event (
 );
 
 CREATE TABLE IF NOT EXISTS public.mixs (
-    pid integer PRIMARY KEY REFERENCES public.sampling_event(pid),
+    pid integer PRIMARY KEY REFERENCES public.sampling_event(pid) ON DELETE CASCADE,
     sop character varying,
     target_gene character varying NOT NULL,
     target_subfragment character varying NOT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS public.emof (
     measurement_unit_id character varying,
     measurement_accuracy character varying,
     measurement_remarks character varying,
-    event_pid integer NOT NULL REFERENCES public.sampling_event(pid),
+    event_pid integer NOT NULL REFERENCES public.sampling_event(pid) ON DELETE CASCADE,
     measurement_determined_date character varying,
     measurement_determined_by character varying,
     measurement_method character varying
@@ -75,8 +75,8 @@ CREATE TABLE IF NOT EXISTS public.asv (
 
 CREATE TABLE IF NOT EXISTS public.occurrence (
     pid BIGSERIAL PRIMARY KEY,
-    event_pid integer REFERENCES public.sampling_event(pid) NOT NULL,
-    asv_pid integer REFERENCES public.asv(pid) NOT NULL,
+    event_pid integer NOT NULL REFERENCES public.sampling_event(pid) ON DELETE CASCADE,
+    asv_pid integer NOT NULL REFERENCES public.asv(pid) ON DELETE CASCADE,
     organism_quantity integer NOT NULL,
     previous_identifications character varying NOT NULL,
     asv_id_alias character varying NOT NULL,
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS public.occurrence (
 
 CREATE TABLE IF NOT EXISTS public.taxon_annotation (
     pid BIGSERIAL PRIMARY KEY,
-    asv_pid  integer REFERENCES public.asv(pid) NOT NULL,
+    asv_pid integer NOT NULL REFERENCES public.asv(pid) ON DELETE CASCADE,
     status character varying NOT NULL,
     kingdom character varying,
     phylum character varying,

--- a/scripts/database-backup.sh
+++ b/scripts/database-backup.sh
@@ -52,6 +52,7 @@ then
 fi
 
 # Load database variables
+# shellcheck disable=SC1090
 . <( grep -e '^POSTGRES' -e '^PG' "$topdir/.env" ) || exit 1
 
 FILE="$topdir/$DIR/${BASE}_$TIMESTAMP.sql"

--- a/scripts/delete-dataset.sh
+++ b/scripts/delete-dataset.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+topdir=$( readlink -f "$( dirname "$0" )/.." )
+
+if [ ! -t 1 ]; then
+	echo 'This script is supposed to be run interactively.'
+	exit 1
+fi >&2
+
+if [ ! -e "$topdir/.env" ]; then
+	printf 'Can not see "%s" to read database configuration.\n' "$topdir/.env"
+	exit 1
+fi >&2
+
+if [ "$( docker container inspect -f '{{ .State.Running }}' asv-db )" != 'true' ]
+then
+	echo 'Container "asv-db" is not available.'
+	exit 1
+fi >&2
+
+. <( grep '^POSTGRES_' "$topdir/.env" ) || exit 1
+
+tput bold
+cat <<'MESSAGE_END'
+*************************************
+*** This script deletes datasets.
+*** Use with care.
+*************************************
+MESSAGE_END
+tput sgr0
+
+do_dbquery () {
+	docker exec asv-db \
+	psql -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+		--quiet --csv \
+		-c "$1"
+}
+
+while true; do
+	readarray -t datasets < <( do_dbquery 'SELECT dataset_id FROM dataset' | sed 1d )
+	nsets=${#datasets[@]}
+
+	printf -v PS3 '\nPlease select dataset to delete (2-%d)\nOr select 1 to quit: ' \
+		"$((nsets + 1 ))"
+
+	select dataset in QUIT "${datasets[@]}"; do
+		if [[ "$REPLY" != *[![:digit:]]* ]] && [ "$REPLY" -ne 0 ]; then
+			if [ "$REPLY" -eq 1 ]; then
+				break 2	# quit
+			elif [ "$REPLY" -le "$(( nsets + 1 ))" ]
+			then
+				break	# other valid choice
+			fi
+		fi
+
+		echo 'Invalid choice.' >&2
+	done
+
+	printf 'Selected "%s"\n' "$dataset"
+done

--- a/scripts/delete-dataset.sh
+++ b/scripts/delete-dataset.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
 
+# This script presents the user with a menu showing the current datasets
+# available in the PostgreSQL database running in the asv-db container.
+# By selecting one of the datasets from the menu, that dataset and all
+# associated data is deleted from the database.
+#
+# The script have no command line opitons and takes no other arguments.
+#
+
 topdir=$( readlink -f "$( dirname "$0" )/.." )
 
+# Refuse to run non-interactively.
 if [ ! -t 1 ]; then
 	echo 'This script is supposed to be run interactively.'
 	exit 1
 fi >&2
+
+#-----------------------------------------------------------------------
+# Perform sanity checks and read database configuration.
+#-----------------------------------------------------------------------
 
 if [ ! -e "$topdir/.env" ]; then
 	printf 'Can not see "%s" to read database configuration.\n' "$topdir/.env"
@@ -23,14 +36,16 @@ fi >&2
 
 tput bold
 cat <<'MESSAGE_END'
-*************************************
-*** This script deletes datasets.
-*** Use with care.
-*************************************
+************************************************************************
+		      This script deletes datasets
+			     Use with care
+************************************************************************
 
 MESSAGE_END
 tput sgr0
 
+# Just a convinience function to send an SQL statement to the database.
+# Initiates a separate session for each call.
 do_dbquery () {
 	docker exec asv-db \
 	psql -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
@@ -38,19 +53,26 @@ do_dbquery () {
 		-c "$1"
 }
 
+# Set up interactive prompt.
 printf -v PS3fmt '%s' \
 	'\n' \
 	'Please select dataset to delete (2-%d),\n' \
 	'or select 1 to quit.\n' \
 	'--> '
 
+#-----------------------------------------------------------------------
+# Main menu loop.
+#-----------------------------------------------------------------------
+
 while true; do
+	# Get list of current datasets.
 	readarray -t datasets < <( do_dbquery 'SELECT dataset_id FROM dataset' | sed 1d )
 	nsets=${#datasets[@]}
 
 	# shellcheck disable=SC2059
 	printf -v PS3 "$PS3fmt" "$(( nsets + 1 ))"
 
+	# Show menu, get input, validate.
 	select dataset in QUIT "${datasets[@]}"; do
 		if [[ "$REPLY" != *[![:digit:]]* ]] && [ "$REPLY" -ne 0 ]; then
 			if [ "$REPLY" -eq 1 ]; then
@@ -64,8 +86,11 @@ while true; do
 		echo 'Invalid choice.' >&2
 	done
 
+	# Perform deletion.
 	printf 'DELETING "%s"...\n' "$dataset"
 	do_dbquery 'DELETE FROM dataset WHERE dataset_id = '"'$dataset'"
 	do_dbquery 'DELETE FROM asv WHERE pid NOT IN (SELECT DISTINCT asv_pid FROM occurrence)'
 	echo 'Done.'
 done
+
+echo 'Bye.'

--- a/scripts/delete-dataset.sh
+++ b/scripts/delete-dataset.sh
@@ -66,5 +66,6 @@ while true; do
 
 	printf 'DELETING "%s"...\n' "$dataset"
 	do_dbquery 'DELETE FROM dataset WHERE dataset_id = '"'$dataset'"
+	do_dbquery 'DELETE FROM asv WHERE pid NOT IN (SELECT DISTINCT asv_pid FROM occurrence)'
 	echo 'Done.'
 done

--- a/scripts/delete-dataset.sh
+++ b/scripts/delete-dataset.sh
@@ -27,6 +27,7 @@ cat <<'MESSAGE_END'
 *** This script deletes datasets.
 *** Use with care.
 *************************************
+
 MESSAGE_END
 tput sgr0
 
@@ -63,5 +64,7 @@ while true; do
 		echo 'Invalid choice.' >&2
 	done
 
-	printf 'Selected "%s"\n' "$dataset"
+	printf 'DELETING "%s"...\n' "$dataset"
+	do_dbquery 'DELETE FROM dataset WHERE dataset_id = '"'$dataset'"
+	echo 'Done.'
 done

--- a/scripts/delete-dataset.sh
+++ b/scripts/delete-dataset.sh
@@ -18,7 +18,7 @@ then
 	exit 1
 fi >&2
 
-# shellcheck source=.env
+# shellcheck disable=SC1090
 . <( grep '^POSTGRES_' "$topdir/.env" ) || exit 1
 
 tput bold

--- a/scripts/delete-dataset.sh
+++ b/scripts/delete-dataset.sh
@@ -18,6 +18,7 @@ then
 	exit 1
 fi >&2
 
+# shellcheck source=.env
 . <( grep '^POSTGRES_' "$topdir/.env" ) || exit 1
 
 tput bold
@@ -36,12 +37,18 @@ do_dbquery () {
 		-c "$1"
 }
 
+printf -v PS3fmt '%s' \
+	'\n' \
+	'Please select dataset to delete (2-%d),\n' \
+	'or select 1 to quit.\n' \
+	'--> '
+
 while true; do
 	readarray -t datasets < <( do_dbquery 'SELECT dataset_id FROM dataset' | sed 1d )
 	nsets=${#datasets[@]}
 
-	printf -v PS3 '\nPlease select dataset to delete (2-%d)\nOr select 1 to quit: ' \
-		"$((nsets + 1 ))"
+	# shellcheck disable=SC2059
+	printf -v PS3 "$PS3fmt" "$(( nsets + 1 ))"
 
 	select dataset in QUIT "${datasets[@]}"; do
 		if [[ "$REPLY" != *[![:digit:]]* ]] && [ "$REPLY" -ne 0 ]; then


### PR DESCRIPTION
Schema changes and script to facilitate easy deletion of datasets.

The schema changes amounts to adding `ON DELETE CASCADE` to foreign key declarations, which makes deletion of rows in a referenced table automatically delete the referring rows in the current table. The actual SQL to delete a dataset and all associated data then becomes trivial.

The script provides an interactive way of seeing the datasets currently available in the `asv-db` container and to delete the one(s) that should no longer be there. It would be wise to do a database backup using the `database-backup.sh` script before actually deleting anything.
