### PR TITLE
On non-Linux systems, use `greadlink` in place of `readlink`

### DIFF
--- a/scripts/database-backup.sh
+++ b/scripts/database-backup.sh
@@ -9,6 +9,13 @@
 # requiring data to be restored with this script, together with a dump
 # produced with 'data' option.
 
+readlink () {
+	case $OSTYPE in
+		linux*) command readlink "$@" ;;
+		*) command greadlink "$@" ;;
+	esac
+}
+
 topdir=$( readlink -f "$( dirname "$0" )/.." )
 
 DIR='db-backup'

--- a/scripts/delete-dataset.sh
+++ b/scripts/delete-dataset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script presents the user with a menu showing the current datasets
 # available in the PostgreSQL database running in the asv-db container.
@@ -7,6 +7,13 @@
 #
 # The script have no command line opitons and takes no other arguments.
 #
+
+readlink () {
+	case $OSTYPE in
+		linux*) command readlink "$@" ;;
+		*) command greadlink "$@" ;;
+	esac
+}
 
 topdir=$( readlink -f "$( dirname "$0" )/.." )
 

--- a/scripts/scheduled-backup.sh
+++ b/scripts/scheduled-backup.sh
@@ -104,6 +104,13 @@ then
 	exit 1
 fi >&2
 
+readlink () {
+        case $OSTYPE in
+                linux*) command readlink "$@" ;;
+                *) command greadlink "$@" ;;
+        esac
+}
+
 topdir=$( readlink -f "$( dirname "$0" )/.." )
 backup_dir=$topdir/backups
 


### PR DESCRIPTION
Make it possible to use some of the scripts on macOS.