### PR TITLE
Script to update annotations

### DIFF
--- a/molmod/requirements.txt
+++ b/molmod/requirements.txt
@@ -18,3 +18,4 @@ pandas==1.2.1
 psycopg2-binary==2.8.6
 openpyxl==3.0.6
 Flask-CAS==1.0.2
+csvkit

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -219,6 +219,12 @@ cat <<-'END_SQL' | do_dbquery
 	FROM tmpdata AS t
 	WHERE ta.asv_pid = t.asv_pid;
 
+	-- "taxon_rank" should be blank rather than NULL.
+	-- https://github.com/biodiversitydata-se/mol-mod/pull/51#issuecomment-855789302
+	UPDATE tmpdata
+	SET taxon_rank = ''
+	WHERE taxon_rank IS NULL;
+
 	-- Finally, copy the data from our temporary table into the
 	-- annotation table.  Avoid inserting data associated with
 	-- sequence data that couldn't be matched.

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -219,11 +219,17 @@ cat <<-'END_SQL' | do_dbquery
 	FROM tmpdata AS t
 	WHERE ta.asv_pid = t.asv_pid;
 
-	-- "taxon_rank" should be blank rather than NULL.
-	-- https://github.com/biodiversitydata-se/mol-mod/pull/51#issuecomment-855789302
-	UPDATE tmpdata
-	SET taxon_rank = ''
-	WHERE taxon_rank IS NULL;
+	-- A number of columns need to be empty strings rather than NULL.
+	-- https://github.com/biodiversitydata-se/mol-mod/pull/51#issuecomment-855902991
+	UPDATE tmpdata SET kingdom = '' WHERE kingdom IS NULL;
+	UPDATE tmpdata SET phylum  = '' WHERE phylum  IS NULL;
+	UPDATE tmpdata SET class   = '' WHERE class   IS NULL;
+	UPDATE tmpdata SET oorder  = '' WHERE oorder  IS NULL;
+	UPDATE tmpdata SET family  = '' WHERE family  IS NULL;
+	UPDATE tmpdata SET genus   = '' WHERE genus   IS NULL;
+	UPDATE tmpdata SET otu     = '' WHERE otu     IS NULL;
+	UPDATE tmpdata SET specific_epithet      = '' WHERE specific_epithet      IS NULL;
+	UPDATE tmpdata SET infraspecific_epithet = '' WHERE infraspecific_epithet IS NULL;
 
 	-- Finally, copy the data from our temporary table into the
 	-- annotation table.  Avoid inserting data associated with

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -48,6 +48,16 @@ do_dbquery () {
 			--no-align --echo-all --tuples-only "$@"
 }
 
+if ! command -v in2csv >/dev/null 2>&1; then
+	cat <<-'END_MESSAGE'
+		The command "in2csv" is not available.
+		Please install the "csvkit" package,
+		either using "pip install csvkit" or
+		via a package manager.
+	END_MESSAGE
+	exit 1
+fi >&2
+
 topdir=$( readlink -f "$( dirname "$0" )/.." )
 
 if [ ! -e "$topdir/.env" ]; then

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -22,28 +22,32 @@ field_name_map=(
 	[taxon_remarks]=taxon_remarks
 )
 
+# Make readlink use GNU readlink on macOS.
 readlink () {
 	case $OSTYPE in
 		linux*)
-			command readlink "$@" ;;
+			command readlink "$@"
+			;;
 		*)
-			command greadlink "$@" ;;
+			command greadlink "$@"
 	esac
 }
 
+# Computes tho AVS hash given a sequence.
+# Uses GNU md5sum.
 asvhash () {
 	printf '%s' "$1" |
 	case $OSTYPE in
 		linux*)
-			command md5sum |
-			cut -d ' ' -f 1
+			command md5sum
 			;;
 		*)
-			command md5 ;;
+			command gmd5sum
 	esac |
-	awk '{ print "ASV:" $0 }'
+	sed 's/^\([[:xdigit:]]\{1,\}\).*/ASV:\1/'
 }
 
+# Simplifies making a query to the database in the asv-db container.
 do_dbquery () {
         # Use --command if we got an argument.  Otherwise, read SQL
         # commands from standard input.

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+# Mapping of the data file's column names to database field names.
+declare -A field_name_map
+field_name_map=(
+	[kingdom]=kingdom
+	[phylum]=phylum
+	[class]=class
+	[order]=oorder
+	[family]=family
+	[genus]=genus
+	[specificEpithet]=specific_epithet
+	[infraspecificEpithet]=infraspecific_epithet
+	[otu]=otu
+	[scientificName]=scientific_name
+	[taxonRank]=taxon_rank
+	[date_identified]=date_identified
+	[reference_db]=reference_db
+	[annotation_algorithm]=annotation_algorithm
+	[identification_references]=identification_references
+	[annotation_confidence]=annotation_confidence
+	[taxon_remarks]=taxon_remarks
+)
+
+readlink () {
+	case $OSTYPE in
+		linux*)
+			command readlink "$@" ;;
+		*)
+			command greadlink "$@" ;;
+	esac
+}
+
+asvhash () {
+	printf '%s' "$1" |
+	case $OSTYPE in
+		linux*)
+			command md5sum |
+			cut -d ' ' -f 1
+			;;
+		*)
+			command md5 ;;
+	esac |
+	awk '{ print "ASV:" $0 }'
+}
+
+do_dbquery () {
+        # Use --command if we got an argument.  Otherwise, read SQL
+        # commands from standard input.
+
+	if [ "$#" -ne 0 ]; then
+		set -- --command="$*"
+	fi
+
+	docker exec -i asv-db \
+		psql -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+		--no-align --quiet --tuples-only "$@"
+}
+
+topdir=$( readlink -f "$( dirname "$0" )/.." )
+
+if [ ! -e "$topdir/.env" ]; then
+	printf 'Can not see "%s" to read database configuration.\n' "$topdir/.env"
+	exit 1
+fi >&2
+
+if [ "$( docker container inspect -f '{{ .State.Running }}' asv-db )" != 'true' ]
+then
+	echo 'Container "asv-db" is not available.'
+	exit 1
+fi >&2
+
+# shellcheck disable=SC1090
+. <( grep '^POSTGRES_' "$topdir/.env" ) || exit 1
+
+indata=$1
+
+if [ -z "$1" ]; then
+	echo 'Missing filename argument'
+	exit 1
+fi >&2
+
+tmpdir=$(mktemp -d)
+
+cleanup () { rm -f -r "$tmpdir"; }
+trap cleanup INT TERM HUP
+
+case $1 in
+	*.csv)	# ok, we want CSV.
+		cp "$1" "$tmpdir/data.csv"
+		;;
+	*.xlsx)	# ok, but need to convert to CSV.
+		in2csv "$1" >"$tmpdir/data.csv"
+		;;
+	*)	# not ok, we got some strange filename.
+		printf 'File has unknown filename suffix: %s\n' "$1" >&2
+		echo 'Expected filename matching *.csv or *.xlsx' >&2
+		exit 1
+esac
+
+indata=$tmpdir/data.csv
+
+# ----------------------------------------------------------------------
+# Verify that each sequence is already in the database.  Do this by
+# calculating the MD5 checksums of the sequences in the CSV file, and
+# then use these to query the database.
+# ----------------------------------------------------------------------
+
+# Get sequences, calculate ASV IDs, put these into an array.
+readarray -t asv_ids < <(
+	csvcut -c asv_sequence "$indata" |
+	while IFS= read -r sequence; do
+		asvhash "$sequence"
+	done
+)
+
+# Get a list of any ASV IDs in the annotation file that are not found in
+# the database.
+readarray -t bad_asv_ids < <(
+	# This bit extracts the IDs that do not exist in the database.
+	# It uses a modified query from
+	# https://dba.stackexchange.com/a/141137
+	cat <<-END_SQL | do_dbquery
+		WITH v (id) AS (
+		VALUES
+		$( printf "\t('%s'),\n" "${asv_ids[@]}" | sed '$s/,$//' )
+		)
+		SELECT v.id
+		FROM v
+		LEFT JOIN asv ON (asv.asv_id = v.id)
+		WHERE asv.asv_id IS NULL
+	END_SQL
+)
+
+# Delete the bad IDs from the array of IDs.
+for bad_id in "${bad_asv_ids[@]}"; do
+	printf 'WARNING: ASV ID "%s" not found in database\n' "$bad_id"
+	for i in "${!asv_ids[@]}"; do
+		[ "${asv_ids[i]}" != "$bad_id" ] && continue
+		unset 'asv_ids[i]'
+		break
+	done
+done
+
+printf '%s\n' "${asv_ids[@]}"
+cleanup

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -43,8 +43,9 @@ do_dbquery () {
 	fi
 
 	docker exec -i asv-db \
-		psql -h localhost -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
-		--no-align --quiet --tuples-only "$@"
+		psql --host=localhost --user="$POSTGRES_USER" \
+			--dbname="$POSTGRES_DB" \
+			--no-align --echo-all --tuples-only "$@"
 }
 
 topdir=$( readlink -f "$( dirname "$0" )/.." )

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -150,7 +150,7 @@ readarray -t bad_asv_ids < <(
 	# https://dba.stackexchange.com/a/141137
 	cat <<-END_SQL | do_dbquery
 		WITH v (id) AS (
-		VALUES (
+		VALUES
 		$( printf "\t('%s'),\n" "${asv_ids[@]}" | sed '$s/,$//' )
 		)
 		SELECT v.id

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -107,10 +107,25 @@ indata=$tmpdir/data.csv
 #REMOVE LATER#csvsql --db "$connstr" --insert "$indata"
 
 # ----------------------------------------------------------------------
+# DATA VERIFICATION
+# ----------------------------------------------------------------------
+
+# Verify that the annotation file contains all the needed columns.
+readarray -t datacols < <( csvcut -n "$indata" | sed 's/.* //' )
+
+for colname in "${!field_name_map[@]}"; do
+	for datacol in "${datacols[@]}"; do
+		if [ "$colname" = "$datacol" ]; then
+			continue 2
+		fi
+	done
+	printf 'Can not find column "%s" in annotation file\n' "$colname" >&2
+	exit 1
+done
+
 # Verify that each sequence is already in the database.  Do this by
 # calculating the MD5 checksums of the sequences in the CSV file, and
 # then use these to query the database.
-# ----------------------------------------------------------------------
 
 # Get sequences, calculate ASV IDs, insert new column ("asv_id") with
 # these.

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Mapping of the data file's column names to database field names.
-declare -A field_name_map
-field_name_map=(
+# Mapping of the data file's column names to database column names.
+declare -A colname_map
+colname_map=(
 	[kingdom]=kingdom
 	[phylum]=phylum
 	[class]=class
@@ -123,6 +123,8 @@ for colname in "${!field_name_map[@]}"; do
 	exit 1
 done
 
+unset datacols datacol
+
 # Verify that each sequence is already in the database.  Do this by
 # calculating the MD5 checksums of the sequences in the CSV file, and
 # then use these to query the database.
@@ -191,10 +193,10 @@ cat <<-END_SQL | do_dbquery
 	)
 END_SQL
 
-names=( "${!field_name_map[@]}" )
-csvcut --columns "$( IFS=,; printf '%s' "${names[*]}" )" "$indata" |
+colnames=( "${!colname_map[@]}" )
+csvcut --columns "$( IFS=,; printf '%s' "${colnames[*]}" )" "$indata" |
 csvformat --out-tabs --out-quoting 1 --out-quotechar "'" | sed 1d |
-while IFS=$'\t' read -r "${names[@]}" junk; do
+while IFS=$'\t' read -r "${colnames[@]}" junk; do
 	echo "$genus"
 done
 

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -111,7 +111,7 @@ indata=$tmpdir/data.csv
 # ----------------------------------------------------------------------
 
 # Verify that the annotation file contains all the needed columns.
-readarray -t datacols < <( csvcut -n "$indata" | sed 's/.* //' )
+readarray -t datacols < <( csvcut --names "$indata" | sed 's/.* //' )
 
 for colname in "${!field_name_map[@]}"; do
 	for datacol in "${datacols[@]}"; do
@@ -130,7 +130,7 @@ done
 # Get sequences, calculate ASV IDs, insert new column ("asv_id") with
 # these.
 readarray -t asv_ids < <(
-	csvcut -c asv_sequence "$indata" | sed 1d |
+	csvcut --columns asv_sequence "$indata" | sed 1d |
 	while IFS= read -r sequence; do
 		asvhash "$sequence"
 	done
@@ -175,8 +175,6 @@ if [ "$#" -ne 0 ]; then
 	cp "$indata" "$indata.tmp"
 	grep -v "$@" "$indata.tmp" >"$indata"
 fi
-
-printf '%s\n' "${asv_ids[@]}"
 
 # ----------------------------------------------------------------------
 # DATA LOADING

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -1,5 +1,38 @@
 #!/usr/bin/env bash
 
+# ======================================================================
+# This script takes an annotation file as its only argument.  The file
+# should be a Microsoft Excel spreadsheet (*.xlsx), or a corresponding
+# CSV file (*.csv).
+#
+# The columns names in the file are expected to be the following (order
+# is *not* important):
+#
+#	annotation_algorithm
+#	annotation_confidence
+#	class
+#	date_identified
+#	family
+#	genus
+#	identification_references
+#	infraspecificEpithet
+#	kingdom
+#	order
+#	otu
+#	phylum
+#	reference_db
+#	scientificName
+#	specificEpithet
+#	taxonRank
+#	taxon_remarks
+#
+# See the associative array "colname_map" below for how these are mapped
+# to column names in the "taxon_annotation" table in the ASV database.
+#
+# The conversation with the database will be shown to the user, as a way
+# of presenting the progress.
+# ======================================================================
+
 # Mapping of the data file's column names to database column names.
 declare -A colname_map
 colname_map=(

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -191,4 +191,11 @@ cat <<-END_SQL | do_dbquery
 	)
 END_SQL
 
+names=( "${!field_name_map[@]}" )
+csvcut --columns "$( IFS=,; printf '%s' "${names[*]}" )" "$indata" |
+csvformat --out-tabs --out-quoting 1 --out-quotechar "'" | sed 1d |
+while IFS=$'\t' read -r "${names[@]}" junk; do
+	echo "$genus"
+done
+
 cleanup

--- a/scripts/update-annotation.sh
+++ b/scripts/update-annotation.sh
@@ -33,6 +33,10 @@
 # of presenting the progress.
 # ======================================================================
 
+# ----------------------------------------------------------------------
+# Setup and sanity checks.
+# ----------------------------------------------------------------------
+
 # Mapping of the data file's column names to database column names.
 declare -A colname_map
 colname_map=(
@@ -128,6 +132,10 @@ case $infile in
 		exit 1
 esac
 
+# ----------------------------------------------------------------------
+# Setup of the staging table in the database.
+# ----------------------------------------------------------------------
+
 # Create a temporary table called "tmpdata".
 cat <<-'END_SQL' | do_dbquery
 	-- We will now create the temporary table that will hold the
@@ -180,6 +188,11 @@ docker exec -i asv-main sh -c '
 	"$@" | sed -e "$colrename" |
 	csvsql --db "$connstr" --insert --tables tmpdata --no-create' sh \
 	"$connstr" "$colrename" "${filter[@]}" <"$infile"
+
+# ----------------------------------------------------------------------
+# Modify the data in the staging table and finally copy the data to the
+# annotation table.
+# ----------------------------------------------------------------------
 
 cat <<-'END_SQL' | do_dbquery
 	-- The data has now been loaded.  We now modify the data


### PR DESCRIPTION
The script takes the pathname of a CSV or XLSX (Microsoft Excel spreadsheet) file on the command line and updates the annotations in the database from it.  This affects only the `taxon_annotation` table. Old annotations on the affected sequences will have their `status` field changed to `old` and newly inserted annotations will have a `status` of `valid`.  Sequences in the provided file that are *not* found in the database will be flagged for the user, and skipped.

