### PR TITLE
Feature/fasta export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,11 @@ blast-copy:
 # Build and copy blastdb into container
 blast: blast-build blast-copy
 
+# Export a fasta file of all ASVs currently annotated with reference database
+# Example: make fasta ref=UNITE:8.0
+fasta:
+	python3 ./scripts/build_blast_db.py --ref $(ref) -v
+
 #
 # Dataset status & visibility
 #

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,16 @@ wait:
 	sleep 10
 
 #
-# DB
+# SECRETS
 #
 
-# Generate passwords, or use existing
 secrets:
 	python3 ./scripts/generate_secrets.py --skip-existing
 
-# Backup postgres data
+#
+# DB BACKUP & RESTORE
+#
+
 backup:
 	./scripts/database-backup.sh data
 
@@ -66,7 +68,7 @@ restore:
 	./scripts/database-backup.sh restore
 
 #
-# BLAST
+# BLAST & FASTA
 #
 
 # Build blastdb from datasets with in_bioatlas = true
@@ -86,17 +88,29 @@ fasta:
 	python3 ./scripts/build_blast_db.py --ref $(ref) -v
 
 #
-# Dataset status & visibility
+# DATA MANIPULATION
 #
 
-# Update in_bioatlas status (to 0/1) for dataset pid and / or (when pid=0)
-# stats view for datasets in_bioatlas = 1
-status:
-	python3 ./scripts/update_bas_status.py --container asv-main $(pid) $(status) $(ruid) -v
+# Import Excel
+# Example: make import file=/some/path/to/file.xlsx
+import:
+	python3 ./scripts/import_excel.py $(file) -v
+dry-import:
+	python3 ./scripts/import_excel.py $(file) -v --dry-run
 
+# Update dataset status
+# Example: make status pid=1 status=0 ruid=dr188
+status:
+	python3 ./scripts/update_bas_status.py --pid $(pid) --status $(status) --ruid $(ruid) -v
 # Update stats view
 stats:
-	python3 ./scripts/update_bas_status.py --container asv-main 0 0 0 -v
+	python3 ./scripts/update_bas_status.py -v
+
 # Display menu for deleting datasets and related data
 delete:
 	./scripts/delete-dataset.sh
+
+# Reannotate ASVs
+reannot:
+	# Example: make reannot file=/some/path/to/file.xlsx
+	./scripts/update-annotation.sh $(file)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -87,6 +87,7 @@ services:
     volumes:
       - blast-db:/blastdbs
       - blastconfig:/root/.config
+      - ./fasta-exports:/worker/fasta-exports
 
   asv-main:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
     volumes:
       - ./blast-databases:/blastdbs
       - blastconfig:/root/.config
+      - ./fasta-exports:/worker/fasta-exports
 
   develop:
     container_name: asv-main

--- a/molmod/importer/importer.py
+++ b/molmod/importer/importer.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
 The mol-mod data importer takes an Excel or Tar file stream, then rearranges
-and inserts the data into the database.
+and inserts the data into the database. The script is executed inside a running
+container using the import_excel.py wrapper.
 """
 
 import hashlib

--- a/scripts/build_blast_db.py
+++ b/scripts/build_blast_db.py
@@ -1,35 +1,31 @@
 #!/usr/bin/env python3
 """
-This is a wrapper script to run the BLAST database builder inside the docker
-container.
+This is a wrapper script to run blast_builder.py inside a docker container.
+To see arguments that can be passed on to the BLAST builder, run:
+docker exec -i mol-mod_blast-worker_1 ./blast_builder/blast_builder.py -h
 """
 
 if __name__ == '__main__':
 
     import argparse
-    import logging
     import subprocess
 
-    #
-    # Use argparse to execute this script using the command-line interpreter,
-    # parse arguments into python object (ARGS), and compose help
-    # (access with './scripts/import_excel.py -h' in molmod dir)
-    #
     # Use docstring as help intro
     PARSER = argparse.ArgumentParser(description=__doc__)
 
     PARSER.add_argument("--container", default="mol-mod_blast-worker_1",
-                        help=("Docker container to execute the blast build "
-                              "script in.")
+                        help="Docker container to execute the blast build "
+                             "script in."
                         )
+    # Parse above argument directly, and pass any additional to script
     ARGS, BUILDER_ARGS = PARSER.parse_known_args()
 
     #
-    # Compose cmd to execute blast_builder.py in container
+    # Compose cmd to execute script in container
     # Path refers to script location inside container
     #
 
     CMD = ["docker", "exec", "-i", ARGS.container,
            "./blast_builder/blast_builder.py"] + BUILDER_ARGS
 
-    BUILDER = subprocess.run(CMD)
+    subprocess.run(CMD)

--- a/scripts/import_excel.py
+++ b/scripts/import_excel.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
 """
 This is a wrapper script to send an Excel data stream (and additional
-arguments) to the data importer inside a running docker-container.
-To see additional arguments, use:
-`docker exec -i asv-main ./molmod/importer/importer.py -h` (in development), or
-`docker exec -i asv-main ./molmod/importer/importer.py -h`
-(in production). Then add them to the wrapper command, e.g:
-`./scripts/import_excel.py file.xlsx -v` ) or e.g.
-`./scripts/import_excel.py --container asv-main file.xlsx -v`
-(in production).
+arguments) to importer.py inside a running docker container.
+To see arguments that can be passed on to the importer, run:
+docker exec -i asv-main ./molmod/importer/importer.py -h
 """
 
 if __name__ == '__main__':
@@ -17,11 +12,6 @@ if __name__ == '__main__':
     import logging
     import subprocess
 
-    #
-    # Use argparse to execute this script using the command-line interpreter,
-    # parse arguments into python object (ARGS), and compose help
-    # (access with './scripts/import_excel.py -h' in molmod dir)
-    #
     # Use docstring as help intro
     PARSER = argparse.ArgumentParser(description=__doc__)
 
@@ -33,11 +23,9 @@ if __name__ == '__main__':
                         help="Docker container to execute import script in. "
                              "Probably asv-main for production env."
                         )
-    PARSER.add_argument("importer_args", nargs=argparse.REMAINDER,
-                        help=("Additional arguments to pass to "
-                              "importer script."))
 
-    ARGS = PARSER.parse_args()
+    # Parse above argument directly, and pass any additional to script
+    ARGS, IMPORTER_ARGS = PARSER.parse_known_args()
 
     #
     # Compose cmd to execute import.py in container
@@ -45,10 +33,10 @@ if __name__ == '__main__':
     #
 
     CMD = ["docker", "exec", "-i", ARGS.container,
-           "./molmod/importer/importer.py"] + ARGS.importer_args
+           "./molmod/importer/importer.py"] + IMPORTER_ARGS
 
     try:
-        IMPORTER = subprocess.run(CMD, stdin=open(ARGS.excel_file))
+        subprocess.run(CMD, stdin=open(ARGS.excel_file))
     except FileNotFoundError:
         logging.error("Could not find input file %s", ARGS.excel_file)
     except IsADirectoryError:

--- a/scripts/update_bas_status.py
+++ b/scripts/update_bas_status.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python3
 """
-This is a wrapper script to run (and pass arguments to) status_updater.py
-inside a running container. To see those additional arguments, use:
-'docker exec -i asv-main ./molmod/importer/status_updater.py -h'
-(in development), or
-'docker exec -i asv-main ./molmod/importer/status_updater.py -h'
-(in production). Then add them to the wrapper command, e.g:
-'./scripts/update_bas_status.py 13 1 dr15 -v --dry-run' (in development) or
-'make status pid=13 status=1 ruid=dr15'(in production).
+This is a wrapper script to run status_updater.py inside a docker container.
+To see arguments that can be passed on to the status updater, run:
+docker exec -i asv-main ./molmod/importer/status_updater.py -h
 """
 
 if __name__ == '__main__':
@@ -15,30 +10,23 @@ if __name__ == '__main__':
     import argparse
     import subprocess
 
-    #
-    # Use argparse to execute this script using the command-line interpreter,
-    # parse arguments into python object (ARGS), and compose help
-    # (access with './scripts/update_bas_status.py -h' in molmod dir)
-    #
     # Use docstring as help intro
     PARSER = argparse.ArgumentParser(description=__doc__)
 
     PARSER.add_argument("--container", default="asv-main",
-                        help="Docker container to execute import script in. "
-                             "Probably asv-main for production env."
+                        help="Docker container to execute the updater "
+                             "script in."
                         )
-    PARSER.add_argument("updater_args", nargs=argparse.REMAINDER,
-                        help=("Additional arguments to pass to "
-                              "updater script."))
 
-    ARGS = PARSER.parse_args()
+    # Parse above argument directly, and pass any additional to script
+    ARGS, PASSED_ARGS = PARSER.parse_known_args()
 
     #
-    # Compose cmd to execute import.py in container
+    # Compose cmd to execute script in container
     # Path refers to script location inside container
     #
 
     CMD = ["docker", "exec", "-i", ARGS.container,
-           "./molmod/importer/status_updater.py"] + ARGS.updater_args
+           "./molmod/importer/status_updater.py"] + PASSED_ARGS
 
-    STATUS_UPDATER = subprocess.run(CMD)
+    subprocess.run(CMD)


### PR DESCRIPTION
Adds possibility to export a fasta file for use in Ampliseq reannotation of eg. all ASVs previously annotated with 'UNITE:8.0' reference db. Also attempts to make usage of e.g. wrappers and argparse for executing scripts in containers more consistent throughout project.