### PR TITLE
Change Matomo siteId

### DIFF
--- a/molmod/templates/matomo.html
+++ b/molmod/templates/matomo.html
@@ -3,15 +3,15 @@
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
     _paq.push(["setCookieDomain", "*.biodiversitydata.se"]);
-    _paq.push(["setDomains", ["*.biodiversitydata.se","*.bioatlas.se","*.sbdi.se"]]);
+    _paq.push(["setDomains", ["*.biodiversitydata.se"]]);
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
         var u="//matomo.biodiversitydata.se/";
         _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '5']);
+        _paq.push(['setSiteId', '15']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
     })();
 </script>
-<noscript><p><img src="//matomo.biodiversitydata.se/matomo.php?idsite=5&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img referrerpolicy="no-referrer-when-downgrade" src="//matomo.biodiversitydata.se/matomo.php?idsite=15&amp;rec=1" style="border:0;" alt="" /></p></noscript>


### PR DESCRIPTION
We're re-configuring Matomo a bit so the ASV-portal has a new siteId.
Merge and deploy when suitable - it's not urgent.